### PR TITLE
[debian] add missing expat build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-inputstream-mpd
 Priority: extra
 Maintainer: peak3d <info@peak3d.de>
 Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 17.0.0),
-               kodi-addon-dev, kodi-inputstream-dev, pkg-config
+               kodi-addon-dev, kodi-inputstream-dev, pkg-config, libexpat1-dev
 Standards-Version: 3.9.6
 Section: libs
 Homepage: http://www.peak3d.de


### PR DESCRIPTION
one more ubuntu packaging fix.
Didn't notice earlier because I had it installed.