### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 

--- a/inputstream.mpd/addon.xml.in
+++ b/inputstream.mpd/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.mpd"
-  version="1.0.4"
+  version="1.1.0"
   name="InputStream MPEG DASH"
   provider-name="peak3d">
   <requires>

--- a/inputstream.mpd/changelog.txt
+++ b/inputstream.mpd/changelog.txt
@@ -1,3 +1,5 @@
+1.1.0
+- cmake: rename find_package kodi to Kodi
 1.0.4
 - support GPAC mpd files, wich transport fragment information in SIDX atom of stream instead inside manifest file
 1.0.3


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in