### PR TITLE
Make Zattoo live stream to work

### DIFF
--- a/src/MainDash.h
+++ b/src/MainDash.h
@@ -111,7 +111,7 @@ public:
   bool CheckChange(bool bSet = false){ bool ret = changed_; changed_ = bSet; return ret; };
   void SetVideoResolution(unsigned int w, unsigned int h) { width_ = w < maxwidth_ ? w : maxwidth_; height_ = h < maxheight_ ? h : maxheight_;};
   bool SeekTime(double seekTime, unsigned int streamId = 0, bool preceeding=true);
-  bool IsLive() const { return dashtree_.live_start_ != 0; };
+  bool IsLive() const { return dashtree_.is_live_; };
 
   //Observer Section
   void BeginFragment(AP4_UI32 streamId) override;

--- a/src/dash/DASHTree.h
+++ b/src/dash/DASHTree.h
@@ -93,7 +93,7 @@ namespace dash
 
     struct Representation
     {
-      Representation() :timescale_(0), duration_(0), bandwidth_(0), samplingRate_(0), width_(0), height_(0),
+      Representation() :timescale_(0), duration_(0), segment_duration_(0), bandwidth_(0), samplingRate_(0), width_(0), height_(0),
         aspect_(1.0f), fpsRate_(0), fpsScale_(1), channelCount_(0), flags_(0), indexRangeMin_(0), indexRangeMax_(0){};
       std::string url_;
       std::string id;
@@ -118,7 +118,7 @@ namespace dash
       uint8_t channelCount_;
       SegmentTemplate segtpl_;
       //SegmentList
-      uint32_t duration_, timescale_;
+      uint32_t duration_, timescale_, segment_duration_;
       Segment initialization_;
       SPINCACHE<Segment> segments_;
       const Segment *get_initialization()const { return (flags_ & INITIALIZATION) ? &initialization_ : 0; };
@@ -143,10 +143,10 @@ namespace dash
 
     struct AdaptationSet
     {
-      AdaptationSet() :type_(NOTYPE), timescale_(0), startPTS_(0){ language_ = "unk"; };
+      AdaptationSet() :type_(NOTYPE), timescale_(0), segment_duration_(0), startPTS_(0){ language_ = "unk"; };
       ~AdaptationSet(){ for (std::vector<Representation* >::const_iterator b(repesentations_.begin()), e(repesentations_.end()); b != e; ++b) delete *b; };
       StreamType type_;
-      uint32_t timescale_;
+      uint32_t timescale_, segment_duration_;
       uint64_t startPTS_;
       std::string language_;
       std::string mimeType_;
@@ -178,6 +178,7 @@ namespace dash
     uint32_t segcount_;
     double overallSeconds_;
     uint64_t stream_start_, live_start_, publish_time_, base_time_;
+    bool is_live_;
     double minPresentationOffset;
 
     uint32_t bandwidth_;

--- a/src/dash/DASHTree.h
+++ b/src/dash/DASHTree.h
@@ -223,7 +223,8 @@ namespace dash
     double get_download_speed() const { return download_speed_; };
     double get_average_download_speed() const { return average_download_speed_; };
     void set_download_speed(double speed);
-    void SetFragmentDuration(const AdaptationSet* adp, const Representation* rep, size_t pos, uint32_t fragmentDuration);
+    void SetSegmentDuration(const AdaptationSet* adp, const Representation* rep, size_t pos, uint64_t pts);
+    void AttachSegment(const AdaptationSet* adp, const Representation* rep, uint64_t pts);
 
     bool empty(){ return !current_period_ || current_period_->adaptationSets_.empty(); };
     const AdaptationSet *GetAdaptationSet(unsigned int pos) const { return current_period_ && pos < current_period_->adaptationSets_.size() ? current_period_->adaptationSets_[pos] : 0; };


### PR DESCRIPTION
Zattoo delivers availabilityStartTime="1970-01-01T00:00:00Z" which is equal to 0. Therefore a new Flag is_live is added
Use the segment duration to increase the segment end instead of the fragment duration
Do not use publishTime for any calculations as it only hols some meta information about the manifest